### PR TITLE
Open new tab via GM_openInTab as a child tab of the caller tab (if Tree Style Tab is installed)

### DIFF
--- a/extension/modules/api.js
+++ b/extension/modules/api.js
@@ -188,6 +188,11 @@ function GM_API(options) {
           aURL, aLoadInBackground, false]);
     }
     else {
+      // open new tab as a child tab of the caller if Tree Style Tab
+      // ( https://addons.mozilla.org/firefox/addon/tree-style-tab/ ) there.
+      if (aChromeWin.TreeStyleTabService &&
+          aChromeWin.TreeStyleTabService.readyToOpenChildTabNow)
+          aChromeWin.TreeStyleTabService.readyToOpenChildTabNow(aSafeWin);
       Scriptish_openInTab(aURL, aLoadInBackground, aReuse, aChromeWin);
     }
 


### PR DESCRIPTION
I got a feedback about compatibility of my addon "Tree Style Tab" and Scriptish: [Issue #276: GM_openInTab open as child scriptish · piroor/treestyletab](https://github.com/piroor/treestyletab/issues/276).
So, I tried to add a hook for GM_openInTab() to call TST's API before new tabs are actually opened.
However, a simple hack https://github.com/piroor/treestyletab/commit/3b9c542e5a67399830a0597bf10f1e9e1a740ee3 didn't work as I expected.

As stability, I think it is better than such a hack in TST-side that calling TST's API by Scriptish itself.

Or, is there any stable API to add extra hacks for GM_openInTab()?

regards,
