### PR TITLE
Onprogress support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # About
 
-Scriptish is a userscript manager for Firefox, forked from Greasemonkey.
+Scriptish-progress is a userscript manager for Firefox, with added support for onprogress event in GM_xmlhttpRequest.
+The original Scriptish available [here](https://github.com/scriptish/scriptish)
 
 
 # Browsers Supported
@@ -8,15 +9,3 @@ Scriptish is a userscript manager for Firefox, forked from Greasemonkey.
 * Firefox 4+
 * Fennec 4+
 * Seamonkey 2.1+
-
-
-# Links
-
-* [Website](http://scriptish.org)
-* [Blog](http://scriptish.org/blog)
-* [Addons.Mozilla.Org (AMO)](https://addons.mozilla.org/firefox/addon/scriptish)
-* [Userscripts](http://userscripts.org)
-* [Wiki](https://github.com/scriptish/scriptish/wiki)
-* [Issues](http://scriptish.lighthouseapp.com/projects/83146-firefox-extension/)
-* [Google Group](http://groups.google.com/group/scriptish)
-* [Source Code](https://github.com/scriptish/scriptish)

--- a/extension/modules/api/GM_xmlhttpRequester.js
+++ b/extension/modules/api/GM_xmlhttpRequester.js
@@ -144,7 +144,7 @@ GM_xmlhttpRequester.prototype.chromeStartRequest =
       details.user || "",
       details.password || ""
       );
-
+  if (details.onprogress) req.onprogress = details.onprogress;
   if (details.overrideMimeType) req.overrideMimeType(details.overrideMimeType);
 
   if (details.ignoreCache)


### PR DESCRIPTION
Onprogress event support added. GM_xmlhttpRequest has this, and it's working without any problems on Firefox 14.0.1. (Other Scriptish-supported browsers were not tested)
