### PR TITLE
Click the scriptish tbb should not disable scriptish

### DIFF
--- a/extension/content/js/browser.js
+++ b/extension/content/js/browser.js
@@ -39,7 +39,6 @@ Scriptish_BrowserUI.tbBtnSetup = function() {
   }
 
   var tbBtnBrd = $("scriptish-button-brd");
-  tbBtnBrd.setAttribute("onclick", "Scriptish_BrowserUIM.onIconClick(event)");
   updateShowScripts();
   Scriptish_prefRoot.watch("enabled", updateShowScripts);
   Scriptish_prefRoot.watch("toolbarbutton.showScripts", updateShowScripts);

--- a/extension/content/third-party/firebug/startButton.css
+++ b/extension/content/third-party/firebug/startButton.css
@@ -7,7 +7,7 @@
   border: 1px solid rgba(0,90,0,0.5);
   margin: 0;
   margin-left: -3px;
-  margin-right: -5px;
+  margin-right: -7px;
 }
 
 /* Slightly different sizes for "small" toolbars */

--- a/extension/content/third-party/firebug/startButton.xml
+++ b/extension/content/third-party/firebug/startButton.xml
@@ -6,18 +6,17 @@
   <binding id="scriptish-button" display="xul:menu"
       extends="chrome://global/content/bindings/toolbarbutton.xml#menu-button">
       <content>
-          <children includes="observes|template|menupopup|panel|tooltip"/>
           <xul:stack>
             <xul:hbox class="badge" pack="center" align="center">
               <xul:label class="label" value="0" xbl:inherits="value=scriptCount"/>
             </xul:hbox>
           </xul:stack>
 
-          <xul:toolbarbutton class="scriptish-button box-inherit toolbarbutton-menubutton-button"
-              anonid="button" flex="1" allowevents="true"
-              xbl:inherits="disabled,crop,image,label,accesskey,command,align,dir,pack,orient"/>
-          <xul:dropmarker type="menu-button" class="toolbarbutton-menubutton-dropmarker"
-              xbl:inherits="align,dir,pack,orient,disabled,label"/>
+          <xul:toolbarbutton class="scriptish-button toolbarbutton-1"
+              anonid="button" flex="1" allowevents="true" type="menu"
+              xbl:inherits="disabled,crop,image,label,accesskey,command,align,dir,pack,orient,scriptish-disabled">
+            <children includes="observes|template|menupopup|panel|tooltip"/>
+          </xul:toolbarbutton>
       </content>
   </binding>
 </bindings>

--- a/extension/skin/browser.css
+++ b/extension/skin/browser.css
@@ -4,17 +4,21 @@
 }
 toolbar #scriptish-button {
   -moz-binding: url("chrome://scriptish/content/third-party/firebug/startButton.xml#scriptish-button");
+  -moz-box-orient: horizontal;
 }
 
-toolbar[iconsize="small"] #scriptish-button {
+.scriptish-button {
+  -moz-box-orient: horizontal !important;
+}
+toolbar[iconsize="small"] .scriptish-button {
   list-style-image: url("chrome://scriptish/skin/scriptish16.png");
 }
 
-#scriptish-button[scriptish-disabled] {
+.scriptish-button[scriptish-disabled] {
   list-style-image: url("chrome://scriptish/skin/scriptish24_disabled.png");
 }
 
-toolbar[iconsize="small"] #scriptish-button[scriptish-disabled] {
+toolbar[iconsize="small"] .scriptish-button[scriptish-disabled] {
   list-style-image: url("chrome://scriptish/skin/scriptish16_disabled.png");
 }
 


### PR DESCRIPTION
The UX of almost every other button I have tried is to open the associated menu when a toolbar button is clicked, but with Scriptish and GM the experience is very different..

There should be a disable/enable menu item, and click the button or badge should open the menu.

Right now the badge opens the menu and the button disables Scriptish..
