### PR TITLE
Fixed #246.

### DIFF
--- a/extension/modules/api/GM_xmlhttpRequester.js
+++ b/extension/modules/api/GM_xmlhttpRequester.js
@@ -140,6 +140,8 @@ GM_xmlhttpRequester.prototype.contentStartRequest = function(details) {
 // that it can access other domains without security warning
 GM_xmlhttpRequester.prototype.chromeStartRequest =
     function(safeUrl, details, req) {
+  details = Components.utils.waiveXrays(details);
+  
   this.setupRequestEvent(this.unsafeContentWin, req, "onload", details);
   this.setupRequestEvent(this.unsafeContentWin, req, "onerror", details);
   this.setupRequestEvent(this.unsafeContentWin, req, "onprogress", details);


### PR DESCRIPTION
Added the use of `waiveXrays` to give the addon scope access to the callback functions from the content scope.

This will fix the issue with `GM_xmlHttpRequest` not working in the Firefox nightly.
