### PR TITLE
Fix typo in typo within GM_log injectScripts file.

### DIFF
--- a/extension/modules/utils/Scriptish_injectScripts.js
+++ b/extension/modules/utils/Scriptish_injectScripts.js
@@ -93,7 +93,7 @@ function Scriptish_injectScripts(options) {
 
     if (!useGrants || script.grant['GM_log']) {
       lazy(sandbox, "GM_log", function() {
-        const _console = GM_getConsoleFor(safeWisafeWin, chromeWin);
+        const _console = GM_getConsoleFor(safeWin, chromeWin);
         if (Scriptish_prefRoot.getValue("logToErrorConsole")) {
           let logger = new GM_ScriptLogger(script);
           return function() {


### PR DESCRIPTION
Fixed an issue introduced in 3fcb12c28f3b89a1ec17da3675f8a7ec41221604 that would cause errors on the api usage within userscripts.

This fixes #271
